### PR TITLE
Fix typo in CookieStore::setPayloadName().

### DIFF
--- a/src/Illuminate/Session/CookieStore.php
+++ b/src/Illuminate/Session/CookieStore.php
@@ -70,14 +70,14 @@ class CookieStore extends Store {
 	}
 
 	/**
-	 * Set the name of the sessoin payload cookie.
+	 * Set the name of the session payload cookie.
 	 *
 	 * @param  string  $name
 	 * @return void
 	 */
 	public function setPayloadName($name)
 	{
-		$this->paylaod = $name;
+		$this->payload = $name;
 	}
 
 	/**


### PR DESCRIPTION
The method was accessing the wrong variable.
